### PR TITLE
Fix powerbanks losing all power when placed when using technic mod.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -41,7 +41,7 @@ local function update_formspec(pos, charge, data)
 
 	local new_formspec = base_formspec..
 		"label[0,0;"..S("Powerbank Mk@1", data.mark).."]"..
-		"label[5.4,2.25;"..S("Power Remaining: @1", technic.pretty_num(charge)).."EU]"..
+		"label[5.4,2.25;"..S("@1", technic.pretty_num(charge)).."EU]"..
 		"box[5.45,1.25;"..(fraction * 2.12)..",0.8;"..color.."]"
 
 	minetest.get_meta(pos):set_string("formspec", new_formspec)


### PR DESCRIPTION
Powerbanks would charge in a battery, then when you go place them, they frustratingly would reset to 0 power. This was because the old `set_charge` and `get_charge` functions (the ones used for technic, NOT technic plus) would always return 0. I fixed this by copying the `default_set_charge` and `default_get_charge` functions from technic's technic/machines/register/battery_box.lua file. Now it works as intended.

I also added a second, optional commit, that makes the "Remaining Charge: ..." part of the formspec more easily visible. Sometimes the number gets cut off, especially on smaller screens.