### PR TITLE
Use item def charge methods

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -85,12 +85,22 @@ local function charge_item(stack, powerbank_charge, charge_step)
 		return powerbank_charge, true
 	end
 	local item_max_charge = technic.power_tools[stack:get_name()]
-	local item_charge = get_charge(stack)
+	local item_def = stack:get_definition()
+	local item_charge
+	if item_def.technic_get_charge then
+		item_charge = item_def.technic_get_charge(stack)
+	else
+		item_charge = get_charge(stack)
+	end
 
 	charge_step = math.min(charge_step, item_max_charge - item_charge, powerbank_charge)
 	item_charge = item_charge + charge_step
 	powerbank_charge = powerbank_charge - charge_step
-	set_charge(stack, item_charge)
+	if item_def.technic_set_charge then
+		item_def.technic_set_charge(stack, item_charge)
+	else
+		set_charge(stack, item_charge)
+	end
 
 	return powerbank_charge, (item_charge == item_max_charge)
 end
@@ -293,3 +303,4 @@ register_powerbank({  -- Powerbank Mk3
 	craft_base = "powerbanks:powerbank_mk2",
 	craft_crystal = "technic:blue_energy_crystal"
 })
+

--- a/init.lua
+++ b/init.lua
@@ -86,17 +86,17 @@ local function charge_item(stack, powerbank_charge, charge_step)
 	end
 	local item_max_charge = technic.power_tools[stack:get_name()]
 	local item_def = stack:get_definition()
-	local item_charge_old
+	local item_charge
 	if item_def.technic_get_charge then
-		item_charge_old = item_def.technic_get_charge(stack)
+		item_charge = item_def.technic_get_charge(stack)
 	else
-		item_charge_old = get_charge(stack)
+		item_charge = get_charge(stack)
 	end
 
-	charge_step = math.min(charge_step, item_max_charge - item_charge_old, powerbank_charge)
-	local item_charge = item_charge_old + charge_step
+	charge_step = math.min(charge_step, item_max_charge - item_charge, powerbank_charge)
+	item_charge = item_charge + charge_step
 	powerbank_charge = powerbank_charge - charge_step
-	if item_charge ~= item_charge_old then
+	if charge_step > 0 then
 		if item_def.technic_set_charge then
 			item_def.technic_set_charge(stack, item_charge)
 		else
@@ -305,4 +305,3 @@ register_powerbank({  -- Powerbank Mk3
 	craft_base = "powerbanks:powerbank_mk2",
 	craft_crystal = "technic:blue_energy_crystal"
 })
-

--- a/init.lua
+++ b/init.lua
@@ -86,20 +86,22 @@ local function charge_item(stack, powerbank_charge, charge_step)
 	end
 	local item_max_charge = technic.power_tools[stack:get_name()]
 	local item_def = stack:get_definition()
-	local item_charge
+	local item_charge_old
 	if item_def.technic_get_charge then
-		item_charge = item_def.technic_get_charge(stack)
+		item_charge_old = item_def.technic_get_charge(stack)
 	else
-		item_charge = get_charge(stack)
+		item_charge_old = get_charge(stack)
 	end
 
-	charge_step = math.min(charge_step, item_max_charge - item_charge, powerbank_charge)
-	item_charge = item_charge + charge_step
+	charge_step = math.min(charge_step, item_max_charge - item_charge_old, powerbank_charge)
+	local item_charge = item_charge_old + charge_step
 	powerbank_charge = powerbank_charge - charge_step
-	if item_def.technic_set_charge then
-		item_def.technic_set_charge(stack, item_charge)
-	else
-		set_charge(stack, item_charge)
+	if item_charge ~= item_charge_old then
+		if item_def.technic_set_charge then
+			item_def.technic_set_charge(stack, item_charge)
+		else
+			set_charge(stack, item_charge)
+		end
 	end
 
 	return powerbank_charge, (item_charge == item_max_charge)


### PR DESCRIPTION
At least with technic.plus, all registered tools have
these methods. Either their own or technic.set_charge
and technig.get_charge respectfully.
See technic/technic/register.lua lines 37 to 39
(part of technic.register_power_tool)

SwissalpS' [replacer] is an example of a tool that provides
functions in item-definition and thus does not work
correctly with [powerbanks].

Also small change to avoid writing meta data
over and over again when nothing changed.
There are other ways to do this, feel free to cherry pick :D